### PR TITLE
allow passing reactRefreshRuntimeFilePathRelativeToPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ import refresh from 'rollup-plugin-react-refresh';
 module.exports = {
     plugins: [
         process.env.NODE_ENV === 'development' && refresh()
+        // If your "react-refresh" is not installed directly next to "rollup-plugin-react-refresh" You might need to pass the option "reactRefreshRuntimeFilePathRelativeToPlugin".
+        // See https://github.com/PepsRyuu/rollup-plugin-react-refresh/pull/10
+        // process.env.NODE_ENV === 'development' && refresh({
+        //    reactRefreshRuntimeFilePathRelativeToPlugin: 'path/to/some/other/node_modules/react-refresh/cjs/react-refresh-runtime.development.js'
+        // })
     ]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,10 +1,31 @@
 let fs = require('fs');
 
-let runtime = fs.readFileSync(require.resolve('react-refresh/cjs/react-refresh-runtime.development.js'), 'utf8');
-
-runtime = runtime.replace('process.env.NODE_ENV', JSON.stringify(process.env.NODE_ENV));
+const DEFAULT_REACT_REFRESH_PATH = '../react-refresh/cjs/react-refresh-runtime.development.js';
 
 function ReactRefresh (opts = {}) {
+    opts.reactRefreshRuntimeFilePathRelativeToPlugin = (
+        opts.reactRefreshRuntimeFilePathRelativeToPlugin ||
+        DEFAULT_REACT_REFRESH_PATH
+    );
+
+    let runtime;
+    try {
+        runtime = fs.readFileSync(require.resolve(opts.reactRefreshRuntimeFilePathRelativeToPlugin), 'utf8');
+    }
+    catch(e) {
+        throw new Error(
+            `[rollup-plugin-react-refresh] ERROR
+Node.js forces "rollup-plugin-react-refresh" to require "react-refresh" via a relative import.
+It seems like the ${opts.reactRefreshRuntimeFilePathRelativeToPlugin == DEFAULT_REACT_REFRESH_PATH ? 'default ': ''}path "${opts.reactRefreshRuntimeFilePathRelativeToPlugin}" did not resolve the file.".
+The resolution has to be from the "rollup-plugin-react-refresh" plugin folder at: "${__dirname}".
+Please fix the plugin option "reactRefreshRuntimeFilePathRelativeToPlugin".
+See https://github.com/PepsRyuu/rollup-plugin-react-refresh/pull/10 for more info.`,
+            {cause: e}
+        );
+    }
+
+    runtime = runtime.replace('process.env.NODE_ENV', JSON.stringify(process.env.NODE_ENV));
+
     return {
         nollupBundleInit () {
             return `

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-react-refresh",
-  "version": "0.0.3",
+  "version": "0.0.4-custom",
   "main": "index.js",
   "author": "Paul Sweeney",
   "license": "MIT",


### PR DESCRIPTION
fixes https://github.com/PepsRyuu/rollup-plugin-react-refresh/issues/9.

The latest versions of Node.js force `rollup-plugin-react-refresh` to require `react-refresh` via a relative import.
See https://nodejs.org/api/packages.html#main-entry-point-export for more details.

This PR allows passing a relative import path as a plugin's option, `reactRefreshRuntimeFilePathRelativeToPlugin`, and sets it to be a default that would work for most of the people:
```diff
- 'react-refresh/cjs/react-refresh-runtime.development.js'
+ const DEFAULT_REACT_REFRESH_PATH = '../react-refresh/cjs/react-refresh-runtime.development.js';
```
It also updates the readme, and adds an error in case there's a problem to resolve `react-refresh-runtime.development.js`.